### PR TITLE
S3 keys support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Optional - If set will be used globally. Will be overwritten when you add S3 set
 | PYU_AWS_SECRET        | You amazon api secret                   |
 | PYU_AWS_SESSION_TOKEN | You amazon api session token (optional) |
 | PYU_AWS_BUCKET        | Bucket name (optional)                  |
-| PYU_AWS_REGION        | AWS Bucket Region (optional)            |
+| PYU_AWS_BUCKET_REGION | AWS Bucket Region (optional)            |
 | PYU_AWS_BUCKET_KEY    | AWS Bucket Key (optional)               |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Optional - If set will be used globally. Will be overwritten when you add S3 set
 
 | Variable              | Meaning                                 |
 | --------------------- |---------------------------------------- |
-| PYU_AWS_ID           | Your amazon api id                      |
-| PYU_AWS_SECRET       | You amazon api secret                   |
+| PYU_AWS_ID            | Your amazon api id                      |
+| PYU_AWS_SECRET        | You amazon api secret                   |
 | PYU_AWS_SESSION_TOKEN | You amazon api session token (optional) |
-| PYU_AWS_BUCKET       | Bucket name (optional)                  |
+| PYU_AWS_BUCKET        | Bucket name (optional)                  |
+| PYU_AWS_REGION        | AWS Bucket Region (optional)            |
+| PYU_AWS_BUCKET_KEY    | AWS Bucket Key (optional)               |


### PR DESCRIPTION
Add support for S3 Bucket Key as well as Region

When configuring env or the plugin the user will have the opportunity to choose their bucket region and essentially subfolder(s).

If accepted please update version, tag it, and push to pypi.