### PR TITLE
Fix check for `bucket_key` not being present.

### DIFF
--- a/s3_uploader.py
+++ b/s3_uploader.py
@@ -148,7 +148,7 @@ class S3Uploader(BaseUploader):
 
                 False - Upload Failed
         """
-        if self.bucket_key is None:
+        if not self.bucket_key:
             key = os.path.basename(filename)
         else:
             key = self.bucket_key + '/' + os.path.basename(filename)


### PR DESCRIPTION
Just spotted this; when initialising `self.bucket_key` is set to an empty string, so this fixes #9!