### PR TITLE
Allow for custom AWS_ENDPOINT_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Optional - If set will be used globally. Will be overwritten when you add S3 set
 | PYU_AWS_BUCKET        | Bucket name (optional)                  |
 | PYU_AWS_BUCKET_REGION | AWS Bucket Region (optional)            |
 | PYU_AWS_BUCKET_KEY    | AWS Bucket Key (optional)               |
+| PYU_AWS_ENDPOINT_URL  | AWS Endpoint URL (optional)             |

--- a/s3_uploader.py
+++ b/s3_uploader.py
@@ -112,18 +112,18 @@ class S3Uploader(BaseUploader):
 
     def _connect(self):
         
-        session_kwargs = dict(
+        session = Session(            
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
             aws_session_token=self.session_token,
             region_name=self.bucket_region
         )
         
+        client_kwargs = dict()
         if self.endpoint_url is not None:
-            session_kwargs['endpoint_url'] = self.endpoint_url
+            client_kwargs['endpoint_url'] = self.endpoint_url
             
-        session = Session(**session_kwargs)
-        self.s3 = session.client('s3')
+        self.s3 = session.client('s3', **client_kwargs)
 
     def set_config(self, config):
         bucket_name = config.get('bucket_name')

--- a/s3_uploader.py
+++ b/s3_uploader.py
@@ -101,16 +101,28 @@ class S3Uploader(BaseUploader):
         # If nothing is set default to bucket root
         if self.bucket_region is None:
             self.bucket_region = 'us-west-2'
+            
+        self.endpoint_url = os.environ.get(u'AWS_ENDPOINT_URL')
+        endpoint_url = config.get(u'endpoint_url')
+        
+        if endpoint_url is not None:
+            self.endpoint_url = endpoint_url
 
         self._connect()
 
     def _connect(self):
-        session = Session(
+        
+        session_kwargs = dict(
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
             aws_session_token=self.session_token,
             region_name=self.bucket_region
         )
+        
+        if self.endpoint_url is not None:
+            session_kwargs['endpoint_url'] = self.endpoint_url
+            
+        session = Session(**session_kwargs)
         self.s3 = session.client('s3')
 
     def set_config(self, config):
@@ -134,6 +146,13 @@ class S3Uploader(BaseUploader):
             default=bucket_region
         )
         config['bucket_region'] = bucket_region
+        
+        endpoint_url = config.get('endpoint_url')
+        endpoint_url = self.get_anwser(
+            'Please enter an endpoint url',
+            default=endpoint_url
+        )
+        config['endpoint_url'] = endpoint_url
 
     def upload_file(self, filename):
         """Uploads a single file to S3

--- a/s3_uploader.py
+++ b/s3_uploader.py
@@ -148,7 +148,7 @@ class S3Uploader(BaseUploader):
         config['bucket_region'] = bucket_region
         
         endpoint_url = config.get('endpoint_url')
-        endpoint_url = self.get_anwser(
+        endpoint_url = self.get_answer(
             'Please enter an endpoint url',
             default=endpoint_url
         )

--- a/s3_uploader.py
+++ b/s3_uploader.py
@@ -102,7 +102,7 @@ class S3Uploader(BaseUploader):
         if self.bucket_region is None:
             self.bucket_region = 'us-west-2'
             
-        self.endpoint_url = os.environ.get(u'AWS_ENDPOINT_URL')
+        self.endpoint_url = os.environ.get(u'PYU_AWS_ENDPOINT_URL')
         endpoint_url = config.get(u'endpoint_url')
         
         if endpoint_url is not None:


### PR DESCRIPTION
I'm testing this out locally and don't want to push changes to S3. I'm using an S3-compliant local file server like https://min.io/. 

boto3 allows you to specify custom endpoint urls: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client

This PR adds in functionality to pass a custom endpoint url via env vars or config.